### PR TITLE
fix message name mistakes

### DIFF
--- a/debunkbot/tasks.py
+++ b/debunkbot/tasks.py
@@ -17,7 +17,7 @@ logger = get_task_logger(__name__)
 # The Intervals should be in minutes.
 DEBUNKBOT_RESPONSE_INTERVAL = int(settings.DEBUNKBOT_RESPONSE_INTERVAL)
 DEBUNKBOT_REFRESH_TRACK_LIST_TIMEOUT = int(settings.DEBUNKBOT_REFRESH_TRACK_LIST_TIMEOUT)
-DEBUNKBOT_CHECK_TWEETS_METRICS = int(settings.DEBUNKBOT_CHECK_TWEETS_METRICS)
+DEBUNKBOT_CHECK_TWEETS_METRICS_INTERVAL = int(settings.DEBUNKBOT_CHECK_TWEETS_METRICS_INTERVAL)
 DEBUNKBOT_CHECK_IMPACT_INTERVAL = int(settings.DEBUNKBOT_CHECK_IMPACT_INTERVAL)
 DEBUNKBOT_BOT_FETCH_RESPONSES_MESSAGES_INTERVAL = int(settings.DEBUNKBOT_BOT_FETCH_RESPONSES_MESSAGES_INTERVAL)
 
@@ -38,7 +38,7 @@ def stream_listener():
     logger.info("Starting stream listener...")
     stream(x)
 
-@periodic_task(run_every=(crontab(minute=f'*/{DEBUNKBOT_CHECK_TWEETS_METRICS}')), name="check_tweet_metrics", ignore_result=True)
+@periodic_task(run_every=(crontab(minute=f'*/{DEBUNKBOT_CHECK_TWEETS_METRICS_INTERVAL}')), name="check_tweet_metrics", ignore_result=True)
 def check_tweet_metrics():
     logger.info(f'Checking metrics of streamed tweets...')
     tweets = Tweet.objects.filter(processed=False, deleted=False)

--- a/debunkbot/twitter/process_stream.py
+++ b/debunkbot/twitter/process_stream.py
@@ -28,17 +28,17 @@ def respond_to_tweet(tweet: Tweet) -> bool:
     """
     api = create_connection()
     try:
-        messages_count = MessageTemplate.objects.count()
-        if messages_count > 0:
-            messages = MessageTemplate.objects.all()
-            message = messages[random.randint(0, messages_count-1)].message
+        message_templates_count = MessageTemplate.objects.count()
+        if message_templates_count > 0:
+            message_templates = MessageTemplate.objects.all()
+            message_template = message_templates[random.randint(0, message_templates_count-1)].message_template
         else:
-            message = "Hey, do you know the link you shared is known to be false?"
+            message_template = "Hey, do you know the link you shared is known to be false?"
 
         if tweet.claim.fact_checked_url:
-                message += f" Check out this link {tweet.claim.fact_checked_url}"
+                message_template += f" Check out this link {tweet.claim.fact_checked_url}"
         our_resp = api.update_status(
-            f"Hello @{tweet.tweet.get('user').get('screen_name')} {message}.",
+            f"Hello @{tweet.tweet.get('user').get('screen_name')} {message_template}.",
             tweet.tweet['id'])
     except tweepy.error.TweepError as error:
         logger.error(f"The following error occurred {error}")


### PR DESCRIPTION
## Description
Some lines in the codebase still reference `Message` when the model has been changed to `MessageTemplate`.  This PR fixes that.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
