### PR TITLE
Url to fetch gsheet claims to db

### DIFF
--- a/debunkbot/urls.py
+++ b/debunkbot/urls.py
@@ -16,6 +16,9 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 
+from debunkbot import views
+
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('fetcher/', views.fetch_gsheet_claims, name='gsheet_fetcher'),
 ]

--- a/debunkbot/views.py
+++ b/debunkbot/views.py
@@ -1,2 +1,8 @@
 from django.http import HttpResponse
 
+from debunkbot.utils.claims_handler import fetch_claims_from_gsheet
+
+
+def fetch_gsheet_claims(request) -> HttpResponse:
+    fetch_claims_from_gsheet()
+    return HttpResponse('All systems go!')


### PR DESCRIPTION
## Description
As a user, I should be able to update the `claims` table locally with data from the google sheets every time I access this URL.

Finishes #173174534

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
