### PR TITLE
Allow filtering of message template without considering case sensitivity

### DIFF
--- a/debunkbot/twitter/process_stream.py
+++ b/debunkbot/twitter/process_stream.py
@@ -16,7 +16,7 @@ def respond_to_tweet(tweet: Tweet) -> bool:
     api = create_connection()
     try:
         message_templates = MessageTemplate.objects.filter(
-            message_template_category=tweet.claim.category
+            message_template_category__iexact=tweet.claim.category
         )
         message_templates_count = message_templates.count()
         if message_templates_count > 0:


### PR DESCRIPTION
## Description

Allow filtering of message template without considering case sensitivity

Fixes # (issue)

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
