### PR TITLE
[Bug] Docker build failing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ ENV PYTHONUNBUFFERED 1
 ####  We need libpq-dev in both build and final runtime image
 RUN apt-get update \
     && apt-get install libpq-dev --no-install-recommends -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean
 
 ###############################################################################
 ## Python builder base image
@@ -28,8 +27,7 @@ FROM python-base AS python-builder-base
 #### System
 RUN apt-get install gcc python-dev --no-install-recommends -y \
     && apt-get clean \
-    && pip install --upgrade pip \
-    && rm -rf /var/lib/apt/lists/*
+    && pip install --upgrade pip
 
 ###############################################################################
 ## Python builder image


### PR DESCRIPTION
## Description
Fixes the issue of docker build failing in GitHub actions due to the package `linux-libc-dev` returning 404 and not installing

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore (non-breaking change which does not add visible functionality but improves code quality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
